### PR TITLE
Allow customizable repository owner username

### DIFF
--- a/sample-projects.yml
+++ b/sample-projects.yml
@@ -1,8 +1,7 @@
-gitCredentials:
-  username: "YOUR-GITHUB-TOKEN"
-  password: "YOUR-GITHUB-TOKEN"
 projects:
-  - repo: github.com/organization/repo-1
+  - repo: repo-1
+    repoOwner: organization
     dir: contracts
-  - repo: github.com/organization/repo-2
+  - repoOwner: organization
+    repo: repo-2
     dir: custom-dir/contracts

--- a/src/config.js
+++ b/src/config.js
@@ -19,10 +19,12 @@ if (!fs.existsSync(tmpDir)) {
 
 const githubToken = process.env.GITHUB_TOKEN || '';
 const projectsYmlPath = process.env.YML_PATH || path.join(__dirname, '..', 'sample-projects.yml');
+const defaultRepoOwner = process.env.DEFAULT_REPOSITORY_OWNER || '';
 
 export default {
   logger,
   tmpDir,
   githubToken,
-  projectsYmlPath
+  projectsYmlPath,
+  defaultRepoOwner
 };

--- a/src/projects/helpers/sync.js
+++ b/src/projects/helpers/sync.js
@@ -5,8 +5,6 @@ import config from '../../config';
 import { ProjectWorkspace } from '../models';
 import ProjectRepository from '../repositories/project';
 
-const ORGANIZATION_NAME = 'omarahm'; //todo: make this configurable
-
 export default {
   /**
    * Synchronize the master branch of all configured projects on startup,
@@ -32,7 +30,7 @@ export default {
 
     const cmd = `
       mkdir -p ${projectWorkspace.getContractsPath()} \\
-        && curl --fail --silent ${authParam} -L 'https://api.github.com/repos/${ORGANIZATION_NAME}/${projectWorkspace
+        && curl --fail --silent ${authParam} -L 'https://api.github.com/repos/${projectWorkspace.owner}/${projectWorkspace
       .project.repo}/tarball/${projectWorkspace.rev}' \\
         | tar xz -C ${projectWorkspace.getPath()} --strip-components 1 --wildcards '*/${projectWorkspace
       .project.dir}/' --anchored

--- a/src/projects/repositories/project.js
+++ b/src/projects/repositories/project.js
@@ -12,7 +12,11 @@ const projectsRaw = yaml.load(fs.readFileSync(config.projectsYmlPath));
 export default {
   async all() {
     return projectsRaw.projects.map(p => {
-      return new Project({ repo: p.repo, dir: _.defaultTo(p.dir, 'contracts') });
+      return new Project({
+        repo: p.repo,
+        dir: _.defaultTo(p.dir, 'contracts'),
+        owner: _.defaultTo(p.repoOwner, config.defaultRepoOwner)
+      });
     });
   },
 

--- a/tests/hooks.js
+++ b/tests/hooks.js
@@ -8,6 +8,7 @@ require('module').Module._initPaths();
 // Global vars
 process.env.TMP_DIR = path.join(__dirname, 'fixtures');
 process.env.YML_PATH = path.join(__dirname, 'fixtures', 'projects.yml');
+process.env.DEFAULT_REPOSITORY_OWNER = 'default-test-organization';
 
 // Global hooks (can+will be overridden on individual suites/specs)
 before(() => {

--- a/tests/projects/helpers/sync_test.js
+++ b/tests/projects/helpers/sync_test.js
@@ -35,7 +35,8 @@ describe('syncProjectWorkspace() in the sync helper', () => {
   it('downloads & unpacks correct contracts/ directory', async () => {
     const workspace = new models.ProjectWorkspace({
       project: new models.Project({ repo: 'notary', dir: 'examples/barebones' }),
-      rev: 'master'
+      rev: 'master',
+      owner: 'omarahm'
     });
 
     await syncHelper.syncProjectWorkspace(workspace);

--- a/tests/projects/repositories/project_test.js
+++ b/tests/projects/repositories/project_test.js
@@ -11,11 +11,27 @@ describe('all() in  projects repository', () => {
   it('returns parsed projects correctly', async () => {
     const actual = await repo.all();
     assert.includeDeepMembers(actual, [
-      new Project({ repo: 'barebones', dir: 'contracts' }),
-      new Project({ repo: 'good-rest-provider', dir: 'contracts' }),
-      new Project({ repo: 'good-rest-consumer', dir: 'contracts' }),
-      new Project({ repo: 'broken-rest-provider', dir: 'contracts' }),
-      new Project({ repo: 'broken-rest-consumer', dir: 'contracts' })
+      new Project({ repo: 'barebones', dir: 'contracts', owner: 'default-test-organization' }),
+      new Project({
+        repo: 'good-rest-provider',
+        dir: 'contracts',
+        owner: 'default-test-organization'
+      }),
+      new Project({
+        repo: 'good-rest-consumer',
+        dir: 'contracts',
+        owner: 'default-test-organization'
+      }),
+      new Project({
+        repo: 'broken-rest-provider',
+        dir: 'contracts',
+        owner: 'default-test-organization'
+      }),
+      new Project({
+        repo: 'broken-rest-consumer',
+        dir: 'contracts',
+        owner: 'default-test-organization'
+      })
       // new Project({ repo: 'good-localstorage-provider', dir: 'contracts' }),
       // new Project({ repo: 'good-localstorage-consumer', dir: 'contracts' }),
       // new Project({ repo: 'broken-localstorage-provider', dir: 'contracts' }),
@@ -25,7 +41,10 @@ describe('all() in  projects repository', () => {
 
   it('returns object with proper default dir of "contracts"', async () => {
     const actual = await repo.all();
-    assert.deepEqual(actual[0], new Project({ repo: 'barebones', dir: 'contracts' }));
+    assert.deepEqual(
+      actual[0],
+      new Project({ repo: 'barebones', dir: 'contracts', owner: 'default-test-organization' })
+    );
   });
 });
 
@@ -38,7 +57,14 @@ describe('findByRepoAndDir() in  projects repository', () => {
 
   it('returns correct object when provided with valid params', async () => {
     const actual = await repo.findByRepoAndDir('good-rest-provider', 'contracts');
-    assert.deepEqual(actual, new Project({ repo: 'good-rest-provider', dir: 'contracts' }));
+    assert.deepEqual(
+      actual,
+      new Project({
+        repo: 'good-rest-provider',
+        dir: 'contracts',
+        owner: 'default-test-organization'
+      })
+    );
   });
 
   it('throws an error when provided with a non-existing repo & dir', async () => {


### PR DESCRIPTION
- Enable setting repository owner in the projects list
- Enable setting a default repository owner via an environment variable, DEFAULT_REPOSITORY_OWNER; this reduces verbosity when nearly all of the projects are owned by a single organization/user